### PR TITLE
Add extensible character sheet tabs

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -48,6 +48,7 @@
 	<script name="RollsManager" file="scripts/manager_rolls.lua" />
 	<script name="TargetingManager" file="scripts/manager_targeting.lua" />
 	<script name="TokenManager" file="scripts/manager_token.lua" />
+	<script name="CharacterSheetManager" file="scripts/manager_charactersheet.lua" />
 	
 	<script name="CharSheetCommon" file="scripts/charsheet_common.lua" />
 	<script name="NPCCommon" file="scripts/npc_common.lua" />

--- a/charsheet_main.xml
+++ b/charsheet_main.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <!-- 
-  -- Please see the readme.txt file included with this distribution for 
-  -- attribution and copyright information.
+    Please see the readme.txt file included with this distribution for 
+    attribution and copyright information.
   -->
 
 <root version="2.6">
@@ -22,7 +22,7 @@
 		
 			<!-- ACTIVATE IDENTITY -->
 			<buttoncontrol>
-				<bounds>-40,30,23,22</bounds>
+				<bounds>-22,30,23,22</bounds>
 				<icon>
 					<normal>button_identityactivate</normal>
 					<pressed>button_identityactivate_down</pressed>

--- a/charsheet_toplevel.xml
+++ b/charsheet_toplevel.xml
@@ -11,11 +11,23 @@
 			<bounds>0,0,-28,-22</bounds>
 		</subwindow>
 	</template>
+	
+	<template name="charsheet_minisheet">
+		<subwindow>
+			<bounds>0,0,-28,-22</bounds>
+		</subwindow>
+	</template>
 
 	<template name="main_charsheet">
 		<charsheet_sheet>
 			<class>charsheet_main</class>
 		</charsheet_sheet>
+	</template>
+
+	<template name="main_minisheet">
+		<charsheet_minisheet>
+			<class>charsheetmini_main</class>
+		</charsheet_minisheet>
 	</template>
 
 	<windowclass name="charsheet">
@@ -126,72 +138,28 @@
 		<minimize />
 		<nodelete />
 		<playercontrol />
-		<script file="scripts/charsheet_toplevel.lua" />
+		<script file="scripts/charsheetmini_toplevel.lua" />
 		<sheetdata>
-			<genericcontrol name="mini_top_frame">
-				<bounds>10,20,-22,40</bounds>
-				<frame>
-					<name>sheetgroup</name>
-				</frame>
-			</genericcontrol>
-			<stringfield name="name">
-				<font>sheettext</font>
-				<frame>
-					<name>textline</name>
-				</frame>
+			<tabcontrol name="tabs">
 				<anchored>
-					<to>mini_top_frame</to>
-					<position>insidetopleft</position>
-					<offset>15,10</offset>
+					<top>
+						<anchor>top</anchor>
+						<offset>50</offset>
+					</top>
+					<right>
+						<anchor>right</anchor>
+						<offset>-10</offset>
+					</right>
 					<size>
-						<width>120</width>
-						<height>20</height>
+						<height>22</height>
+						<width>18</width>
 					</size>
 				</anchored>
-				<static />
-			</stringfield>
-			
-			<!-- ACTIVATE IDENTITY -->
-			<buttoncontrol>
-				<bounds>-35,30,23,22</bounds>
-				<icon>
-					<normal>button_identityactivate</normal>
-					<pressed>button_identityactivate_down</pressed>
-				</icon>
-				<script>
-					function onInit()
-						if User.isLocal() then
-							setVisible(false);
-						end
-					end
-					
-					function onButtonPress()
-						if User.isLocal() then
-							return;
-						end
-						
-						if User.isHost() then
-							GmIdentityManager.addIdentity(window.name.getValue());
-						else
-							local identityname = window.getDatabaseNode().getName();
-
-							User.setCurrentIdentity(identityname);
-
-							if CampaignRegistry and CampaignRegistry.colortables and CampaignRegistry.colortables[identityname] then
-								local colortable = CampaignRegistry.colortables[identityname];
-								User.setCurrentIdentityColors(colortable.color or "000000", colortable.blacktext or false);
-							end
-						end
-					end
-				</script>
-			</buttoncontrol>
-		
-
-			<subwindow name="main">
-				<bounds>10,50,-22,-1</bounds>
-				<class>charsheetmini_basic</class>
-			</subwindow>
-			
+				<frame>
+					<name>tabs</name>
+				</frame>
+				<tabtopicon>tabtop</tabtopicon>
+			</tabcontrol>
 			
 			<windowreferencecontrol>
 				<bounds>10,-25,40,15</bounds>
@@ -226,15 +194,6 @@
 					end
 				</script>
 			</windowreferencecontrol>
-
-			<tabcontrol name="tabs">
-				<bounds>-22,50,18,291</bounds>
-				<tab>
-					<icon>tab_main</icon>
-					<subwindow>main</subwindow>
-				</tab>
-				<activate>1</activate>
-			</tabcontrol>
 			
 			<closebutton_charsheetmini />
 		</sheetdata>

--- a/charsheet_toplevel.xml
+++ b/charsheet_toplevel.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <!-- 
-  -- Please see the readme.txt file included with this distribution for 
-  -- attribution and copyright information.
+    Please see the readme.txt file included with this distribution for 
+    attribution and copyright information.
   -->
 
 <root version="2.6">
+	<template name="charsheet_sheet">
+		<subwindow>
+			<bounds>0,0,-28,-22</bounds>
+		</subwindow>
+	</template>
+
+	<template name="main_charsheet">
+		<charsheet_sheet>
+			<class>charsheet_main</class>
+		</charsheet_sheet>
+	</template>
+
 	<windowclass name="charsheet">
 		<frame>charsheet</frame>
 		<placement>
@@ -33,6 +45,26 @@
 		<playercontrol />
 		<script file="scripts/charsheet_toplevel.lua" />
 		<sheetdata>
+			<tabcontrol name="tabs">
+				<anchored>
+					<top>
+						<anchor>top</anchor>
+						<offset>50</offset>
+					</top>
+					<right>
+						<anchor>right</anchor>
+						<offset>-10</offset>
+					</right>
+					<size>
+						<height>22</height>
+						<width>18</width>
+					</size>
+				</anchored>
+				<frame>
+					<name>tabs</name>
+				</frame>
+				<tabtopicon>tabtop</tabtopicon>
+			</tabcontrol>
 			<windowreferencecontrol>
 				<bounds>10,-25,40,15</bounds>
 				<icon>
@@ -66,21 +98,6 @@
 					end
 				</script>
 			</windowreferencecontrol>
-
-			<subwindow name="main">
-				<bounds>0,0,-1,-22</bounds>
-				<class>charsheet_main</class>
-			</subwindow>
-			
-			<tabcontrol name="tabs">
-				<bounds>-22,50,18,87</bounds>
-				<tab>
-					<icon>tab_main</icon>
-					<subwindow>main</subwindow>
-				</tab>
-				<activate>1</activate>
-			</tabcontrol>
-		
 			<closebutton_charsheet />
 		</sheetdata>
 	</windowclass>

--- a/charsheetmini_main.xml
+++ b/charsheetmini_main.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 
 <!-- 
-  -- Please see the readme.txt file included with this distribution for 
-  -- attribution and copyright information.
+    Please see the readme.txt file included with this distribution for 
+    attribution and copyright information.
   -->
 
 <root version="2.6">
-	<windowclass name="charsheetmini_basic">
+	<windowclass name="charsheetmini_main">
 		<placement>
 			<size>
 				<width>360</width>
@@ -15,6 +15,65 @@
 		</placement>
 		<nodelete />
 		<sheetdata>
+			
+			<genericcontrol name="mini_top_frame">
+				<bounds>10,20,-28,40</bounds>
+				<frame>
+					<name>sheetgroup</name>
+				</frame>
+			</genericcontrol>
+			<stringfield name="name">
+				<font>sheettext</font>
+				<frame>
+					<name>textline</name>
+				</frame>
+				<anchored>
+					<to>mini_top_frame</to>
+					<position>insidetopleft</position>
+					<offset>15,10</offset>
+					<size>
+						<width>120</width>
+						<height>20</height>
+					</size>
+				</anchored>
+				<static />
+			</stringfield>
+		
+		
+			<!-- ACTIVATE IDENTITY -->
+			<buttoncontrol>
+				<bounds>-22,30,23,22</bounds>
+				<icon>
+					<normal>button_identityactivate</normal>
+					<pressed>button_identityactivate_down</pressed>
+				</icon>
+				<script>
+					function onInit()
+						if User.isLocal() then
+							setVisible(false);
+						end
+					end
+					
+					function onButtonPress()
+						if User.isLocal() then
+							return;
+						end
+						
+						if User.isHost() then
+							GmIdentityManager.addIdentity(window.name.getValue());
+						else
+							local identityname = window.getDatabaseNode().getName();
+
+							User.setCurrentIdentity(identityname);
+
+							if CampaignRegistry and CampaignRegistry.colortables and CampaignRegistry.colortables[identityname] then
+								local colortable = CampaignRegistry.colortables[identityname];
+								User.setCurrentIdentityColors(colortable.color or "000000", colortable.blacktext or false);
+							end
+						end
+					end
+				</script>
+			</buttoncontrol>
 			
 		</sheetdata>
 	</windowclass>

--- a/scripts/charsheet_toplevel.lua
+++ b/scripts/charsheet_toplevel.lua
@@ -4,10 +4,23 @@
 --
 
 function onInit()
-	if User.isHost() then
+	User.onIdentityActivation = onIdentityActivation;
+	CharacterSheetManager.populate(self)
+end
+
+-- Close this sheet if the user releases its identity
+function onIdentityActivation(identity, username, activated)
+	if not activated and User.getUsername() == username and identity == getDatabaseNode().getName() then
+		close()
 	end
 end
 
-function onMenuSelection(selection, subselection)
-	
+function onMenuSelection(selection, subselection)	
+
+end
+
+-- callback method for CharacterSheetManager to add sheets to this window
+function addSheet(name, windowclass, tabicon)
+	createControl(windowclass, name)
+	tabs.registerTab(name, tabicon)
 end

--- a/scripts/charsheetmini_toplevel.lua
+++ b/scripts/charsheetmini_toplevel.lua
@@ -5,7 +5,7 @@
 
 function onInit()
 	User.onIdentityActivation = onIdentityActivation;
-	CharacterSheetManager.populate("main", self)
+	CharacterSheetManager.populate("mini", self)
 end
 
 -- Close this sheet if the user releases its identity

--- a/scripts/manager_charactersheet.lua
+++ b/scripts/manager_charactersheet.lua
@@ -1,0 +1,70 @@
+-- 
+-- Please see the readme.txt file included with this distribution for 
+-- attribution and copyright information.
+--
+
+--
+-- CHARACTER SHEET MANAGER
+--   - Authored by Ben Turner (phantomwhale)
+--
+-- This manager script allows extensions to define the "sheets" to include on the character sheet.
+-- This is done by registering / deregistering sheets on start up. See the function descriptions below
+-- for how to use this script.
+--
+-- The default behaviour is to register a single sheet called "main" - see the onInit() method.
+--
+
+-- Stores the list of sheets
+local sheets = {};
+
+--
+-- Registers a single sheet called main, using the "main_charsheet" windowclass and the "tab_main" graphic for the tab text
+function onInit()
+	registerSheet("main", "main_charsheet", "tab_main")
+end
+
+-- Registers a sheet for inclusion on character sheets
+--
+-- Params:
+--   name        - name of the sheet, which must be unique. Attempts to register a second sheet of the same name will remove the old sheet, taking it's place if the before parameter has not been specified
+--   windowclass - the name of the windowclass or template to be created for this particular sheet
+--   tabicon     - the name of the icon contained the tab image (usually text to appear over the background tab)
+--   before      - if specified, tab will be added before the tab of this name. If no such tab of that name has been registered, or the parameter is not supplied, then the tab will be added to the end of the list
+--
+function registerSheet(name, windowclass, tabicon, before)
+	local index = #sheets+1
+	for key,sheet in ipairs(sheets) do
+		if sheet.name == name then
+			table.remove(sheets, key)
+			index = key
+		end
+		index = (sheet.name == before) and key or index
+	end
+	table.insert(sheets, index, {name = name, windowclass = windowclass, tabicon = tabicon})
+end
+
+--
+-- Removes a sheet from the resistry
+--
+-- Params:
+--   name        - name of the sheet you wish to remove from the character sheet
+--
+function deregisterSheet(name)
+	for key,sheet in ipairs(sheets) do
+		if sheet.name == name then
+			table.remove(sheets, key)
+		end
+	end
+end
+	
+--
+-- Populate the character sheet window with the registered sheets
+--
+-- Params:
+--  win          - character sheet window to be populated
+--	
+function populate(win)
+	for _,sheet in ipairs(sheets) do
+		win.addSheet(sheet.name, sheet.windowclass, sheet.tabicon)
+	end
+end

--- a/scripts/manager_charactersheet.lua
+++ b/scripts/manager_charactersheet.lua
@@ -14,57 +14,71 @@
 -- The default behaviour is to register a single sheet called "main" - see the onInit() method.
 --
 
--- Stores the list of sheets
+-- Hash of catgeories to lists of sheets
 local sheets = {};
 
 --
--- Registers a single sheet called main, using the "main_charsheet" windowclass and the "tab_main" graphic for the tab text
+-- Registers a sheet called "mainsheet", using the "main_charsheet" windowclass and the "tab_main" graphic for the tab text
+-- Does this for both main and minisheet tab sets
+--
 function onInit()
-	registerSheet("main", "main_charsheet", "tab_main")
+	registerSheet("main", "mainsheet", "main_charsheet", "tab_main")
+	registerSheet("mini", "mainsheet", "main_minisheet", "tab_main")
 end
+
 
 -- Registers a sheet for inclusion on character sheets
 --
 -- Params:
+--   category    - category for this sheet - usually "main" or "mini"
 --   name        - name of the sheet, which must be unique. Attempts to register a second sheet of the same name will remove the old sheet, taking it's place if the before parameter has not been specified
 --   windowclass - the name of the windowclass or template to be created for this particular sheet
 --   tabicon     - the name of the icon contained the tab image (usually text to appear over the background tab)
 --   before      - if specified, tab will be added before the tab of this name. If no such tab of that name has been registered, or the parameter is not supplied, then the tab will be added to the end of the list
 --
-function registerSheet(name, windowclass, tabicon, before)
-	local index = #sheets+1
-	for key,sheet in ipairs(sheets) do
+function registerSheet(category, name, windowclass, tabicon, before)
+  sheets[category] = sheets[category] or {}
+	local index = #sheets[category] + 1
+	for key,sheet in ipairs(sheets[category]) do
 		if sheet.name == name then
-			table.remove(sheets, key)
+			table.remove(sheets[category], key)
 			index = key
 		end
 		index = (sheet.name == before) and key or index
 	end
-	table.insert(sheets, index, {name = name, windowclass = windowclass, tabicon = tabicon})
+	table.insert(sheets[category], index, {name = name, windowclass = windowclass, tabicon = tabicon})
 end
 
 --
 -- Removes a sheet from the resistry
 --
 -- Params:
+--   category    - category for this sheet - usually "main" or "mini"
 --   name        - name of the sheet you wish to remove from the character sheet
 --
-function deregisterSheet(name)
-	for key,sheet in ipairs(sheets) do
+function deregisterSheet(category, name, windowclass, tabicon, before)
+	sheets[category] = sheets[category] or {}
+	for key,sheet in ipairs(sheets[category]) do
 		if sheet.name == name then
-			table.remove(sheets, key)
+			table.remove(sheets.category, key)
 		end
 	end
 end
+	
+-- 
+-- PUBLIC FUNCTIONS
+--
 	
 --
 -- Populate the character sheet window with the registered sheets
 --
 -- Params:
---  win          - character sheet window to be populated
+--   category    - category for this sheet - usually "main" or "mini"
+--   win         - character sheet window to be populated
 --	
-function populate(win)
-	for _,sheet in ipairs(sheets) do
+function populate(category, win)
+	for _,sheet in ipairs(sheets[category]) do
 		win.addSheet(sheet.name, sheet.windowclass, sheet.tabicon)
 	end
 end
+

--- a/scripts/template_tabcontrol.lua
+++ b/scripts/template_tabcontrol.lua
@@ -3,77 +3,83 @@
 -- attribution and copyright information.
 --
 
+local TAB_SIZE = 67
 local topWidget = nil;
 local tabIndex = 1;
-local tabWidgets = {};
-
-function getIndex()
-	return tabIndex;
-end
+local tabs = {};
 
 function activateTab(index)
-	-- Hide active tab, fade text labels
-	tabWidgets[tabIndex].setColor("80ffffff");
-	window[tab[tabIndex].subwindow[1]].setVisible(false);
-	if tab[tabIndex].scroller then
-		window[tab[tabIndex].scroller[1]].setVisible(false);
-	end
+	index = tonumber(index);
+	if index > 0 and index < #tabs+1 then
+		-- Hide active tab, fade text labels
+		tabs[tabIndex].widget.setColor("80ffffff");
+		window[tabs[tabIndex].subwindow].setVisible(false);
+		if tabs[tabIndex].scroller then
+			window[tabs[tabIndex].scroller].setVisible(false);
+		end 
 
-	-- Set new index
-	tabIndex = tonumber(index);
+		-- Set new index
+		tabIndex = index;
 
-	-- Move helper graphic into position
-	topWidget.setPosition("topleft", 5, 67*(tabIndex-1)+7);
-	if tabIndex == 1 then
-		topWidget.setVisible(false);
-	else
-		topWidget.setVisible(true);
-	end
-	
-	-- Activate text label and subwindow
-	tabWidgets[tabIndex].setColor("ffffffff");
+		-- Move helper graphic into position
+		topWidget.setPosition("topleft", 5, TAB_SIZE*(tabIndex-1)+7);
+		if tabIndex == 1 then
+			topWidget.setVisible(false);
+		else
+			topWidget.setVisible(true);
+		end
+		
+		-- Activate text label and subwindow
+		tabs[tabIndex].widget.setColor("ffffffff");
 
-	window[tab[tabIndex].subwindow[1]].setVisible(true);
-	if tab[tabIndex].scroller then
-		window[tab[tabIndex].scroller[1]].setVisible(true);
+		window[tabs[tabIndex].subwindow].setVisible(true);
+		for _,tab in pairs(tabs) do
+			tab.widget.bringToFront();
+		end
+		if tabs[tabIndex].scroller then
+			window[tabs[tabIndex].scroller].setVisible(true);
+		end
 	end
 end
 
 function onClickDown(button, x, y)
-	return true;
-end
-
-function onClickRelease(button, x, y)
-	local i = math.ceil(y/67);
+	local i = math.ceil(y/TAB_SIZE);
 	
-	-- Make sure index is in range and activate selected
-	if i > 0 and i < #tab+1 then
-		activateTab(i);
-	end
-	
-	return true;
+	activateTab(i);
 end
 
 function onDoubleClick(x, y)
-	-- Emulate click
-	onClickRelease(1, x, y);
+	-- Emulate single click
+	onClickDown(1, x, y);
+end
+
+function registerTab(name, icon, scroller)
+	local widget = addBitmapWidget(icon);
+	widget.setPosition("topleft", 7, TAB_SIZE*(#tabs)+41);
+	widget.setColor("80ffffff");
+	widget.bringToFront();
+	tabs[#tabs+1] = {widget = widget, subwindow = name, scroller = scroller};
+	
+	setAnchoredHeight(22 + #tabs * TAB_SIZE);
+	
+	if #tabs == 1 then 
+		activateTab(1);
+	end
 end
 
 function onInit()
 	-- Create a helper graphic widget to indicate that the selected tab is on top
-	topWidget = addBitmapWidget("tabtop");
+	topWidget = addBitmapWidget(tabtopicon[1]);
 	topWidget.setVisible(false);
 
-	-- Deactivate all labels	
-	for n, v in ipairs(tab) do
-		tabWidgets[n] = addBitmapWidget(v.icon[1]);
-		tabWidgets[n].setPosition("topleft", 7, 67*(n-1)+41);
-		tabWidgets[n].setColor("80ffffff");
+	-- as we're have a merge rule set for tabs, an "empty" implementation will still have tab set to {1 = TRUE}
+	if #tab > 1 or tab[1] ~= true then
+		for _,t in ipairs(tab) do
+			registerTab(t.subwindow[1], t.icon[1], t.scroller and t.scroller[1] or nil);
+		end
 	end
-
+	
 	if activate then
 		activateTab(activate[1]);
-	else
-		activateTab(1);
 	end
 end

--- a/templates_common.xml
+++ b/templates_common.xml
@@ -521,6 +521,7 @@
 			<frame>
 				<name>tabs</name>
 			</frame>
+			<tabtopicon>tabtop</tabtopicon>
 			<script file="scripts/template_tabcontrol.lua" />
 		</genericcontrol>
 	</template>


### PR DESCRIPTION
This code should allow extensions to easily define the character sheet tabs. By overriding the charsheet_main and charsheetmini_main classes, the two main sheets can be modified. Or these tabs can be removed via the CharsheetManager library, which also allows new tabs to be registered and ordered correctly.
