### PR TITLE
Changes to draggable objects and CT footer

### DIFF
--- a/templates_common.xml
+++ b/templates_common.xml
@@ -362,7 +362,7 @@
 					setHoverCursor("hand");
 				end
 			
-				function onDrag(button, x, y, draginfo)
+				function onDragStart(button, x, y, draginfo)
 					if dragging then
 						return true;
 					end

--- a/utility_characterlist.xml
+++ b/utility_characterlist.xml
@@ -47,7 +47,7 @@
 						return true;
 					end
 
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if User.isHost() then
 							if dragging then
 								return true;

--- a/utility_combattracker.xml
+++ b/utility_combattracker.xml
@@ -1554,7 +1554,7 @@
 			
 			<!-- FOOTER CONTROLS -->
 			<genericcontrol name="icon_setactive">
-				<bounds>28,-53,33,40</bounds>
+				<bounds>28,-60,33,40</bounds>
 				<activeicon>indicator_ctactive</activeicon>
 				<script>
 					function onInit()
@@ -1575,7 +1575,7 @@
 				</script>
 			</genericcontrol>
 			<buttoncontrol name="advance_actor">
-				<bounds>62,-45,33,26</bounds>
+				<bounds>62,-55,33,26</bounds>
 				<icon>
 					<normal>button_ctnextactor</normal>
 					<pressed>button_ctnextactor_down</pressed>
@@ -1607,7 +1607,7 @@
 			</buttoncontrol>
 
 			<combattrackerffsource name="ffsource_friend">
-				<bounds>200,-43,20,20</bounds>
+				<bounds>200,-52,20,20</bounds>
 				<icon>indicator_ctfffriend</icon>
 				<value>friend</value>
 				<tooltip>
@@ -1615,7 +1615,7 @@
 				</tooltip>
 			</combattrackerffsource>
 			<combattrackerffsource name="ffsource_neutral">
-				<bounds>227,-43,20,20</bounds>
+				<bounds>227,-52,20,20</bounds>
 				<icon>indicator_ctffneutral</icon>
 				<value>neutral</value>
 				<tooltip>
@@ -1623,7 +1623,7 @@
 				</tooltip>
 			</combattrackerffsource>
 			<combattrackerffsource name="ffsource_foe">
-				<bounds>254,-43,20,20</bounds>
+				<bounds>254,-52,20,20</bounds>
 				<icon>indicator_ctfffoe</icon>
 				<value>foe</value>
 				<tooltip>
@@ -1632,7 +1632,7 @@
 			</combattrackerffsource>
 			
 			<buttoncontrol name="button_menu">
-				<bounds>-210,-40,40,15</bounds>
+				<bounds>-210,-50,40,15</bounds>
 				<icon>
 					<normal>button_menu</normal>
 					<pressed>button_menu_down</pressed>
@@ -1699,7 +1699,7 @@
 					</right>
 					<top>
 						<anchor>bottom</anchor>
-						<offset>-39</offset>
+						<offset>-50</offset>
 					</top>
 					<size>
 						<width>50</width>

--- a/utility_combattracker.xml
+++ b/utility_combattracker.xml
@@ -55,12 +55,12 @@
 			<genericcontrol name="base">
 				<bounds>0,0,-1,-1</bounds>
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -120,12 +120,12 @@
 						end
 					end
 
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -245,12 +245,12 @@
 					<type>combattrackerentry</type>
 				</droptypes>
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -299,12 +299,12 @@
 				</droptypes>
 				<invisible />
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -370,12 +370,12 @@
 						end
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -440,12 +440,12 @@
 						end
 					end
 
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -487,7 +487,7 @@
 						registerMenuItem("Target all non-allies", "mask", 4, 5);
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
@@ -1027,7 +1027,7 @@
 						end
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if User.isHost() then
 							if dragging then
 								return true;
@@ -1140,7 +1140,7 @@
 						registerMenuItem("Target all non-allies", "mask", 4, 5);
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
@@ -1588,7 +1588,7 @@
 						window.list.nextActor();
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
@@ -1754,7 +1754,7 @@
 						window.list.nextRound();
 					end
 					
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end

--- a/utility_effects.xml
+++ b/utility_effects.xml
@@ -46,7 +46,7 @@
 				return rEffect;
 			end
 			
-			function onDrag(button, x, y, draginfo)
+			function onDragStart(button, x, y, draginfo)
 				return RulesManager.dragEffect(draginfo, nil, getEffectStructure());
 			end
 			
@@ -106,12 +106,12 @@
 				<gmonly />
 				<script>
 										
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 
@@ -190,12 +190,12 @@
 				</anchored>
 				<gmonly />
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 

--- a/utility_modifiers.xml
+++ b/utility_modifiers.xml
@@ -29,7 +29,7 @@
 				end
 			end
 			
-			function onDrag(button, x, y, draginfo)
+			function onDragStart(button, x, y, draginfo)
 				if label.getValue() ~= "" then
 					draginfo.setType("number");
 					draginfo.setDescription(label.getValue());
@@ -91,12 +91,12 @@
 				</droptypes>
 				<gmonly />
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return dragging;
 					end
 
@@ -161,12 +161,12 @@
 				</anchored>
 				<gmonly />
 				<script>
-					function onDrag(button, x, y, draginfo)
+					function onDragStart(button, x, y, draginfo)
 						if dragging then
 							return true;
 						end
 						
-						dragging = window.onDrag(button, x, y, draginfo);
+						dragging = window.onDragStart(button, x, y, draginfo);
 						return true;
 					end
 


### PR DESCRIPTION
Made changes to files, substituting onDrag for onDragStart to fix issues with draggable objects. These include the combat tracker turn flag and the Friendly/Neutral/Foe markers. I think I've possibly duplicated the change that Dan has done regarding dragging the character from the character list to the combat tracker.
Also changes the locations of the combat tracker footer objects to fir them within the CT graphic.
